### PR TITLE
Make field constructor implicit

### DIFF
--- a/JAVA.md
+++ b/JAVA.md
@@ -665,7 +665,7 @@ Create a new template component that will be used to create new Bootstrap-friend
 Update the `app/views/index.scala.html` file to use Bootstrap for a nice header, better layout, and nicer default fonts:
 
     @(message: String, taskForm: Form[Task])
-    @implicitFieldConstructor = { helper.FieldConstructor(twitterBootstrapInput.render) }
+    @implicitFieldConstructor = @{ helper.FieldConstructor(twitterBootstrapInput.render) }
     
     @main("Welcome to Play 2.0") {
     


### PR DESCRIPTION
Without the implicit constructor, the Twitter Bootstrap field constructor isn't used at all. 

I'm not sure why Maurizio couldn't compile this but since James said he was able to compile it (https://github.com/jamesward/play2torial/pull/2) and I as well, it probably was something on Maurizio's end. 
